### PR TITLE
feat(release): npm publishing, release workflow, and changelog (#52)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,98 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  release:
+    name: Build & Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run tests
+        run: bun run test:run
+
+      - name: Build
+        run: bun run build
+
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+
+      - name: Create release archive
+        run: |
+          tar -czf agent-config-manager-${{ steps.version.outputs.VERSION }}.tar.gz dist/ bin/ README.md LICENSE package.json
+          zip -r agent-config-manager-${{ steps.version.outputs.VERSION }}.zip dist/ bin/ README.md LICENSE package.json
+
+      - name: Extract release notes
+        id: release_notes
+        run: |
+          # Extract section for this version from CHANGELOG.md
+          VERSION="${{ steps.version.outputs.VERSION }}"
+          NOTES=$(awk "/^## \[$VERSION\]/{found=1; next} found && /^## /{exit} found{print}" CHANGELOG.md)
+          if [ -z "$NOTES" ]; then
+            NOTES="See CHANGELOG.md for details."
+          fi
+          {
+            echo "NOTES<<EOF"
+            echo "$NOTES"
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: Agent Config Manager v${{ steps.version.outputs.VERSION }}
+          body: ${{ steps.release_notes.outputs.NOTES }}
+          draft: false
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          files: |
+            agent-config-manager-${{ steps.version.outputs.VERSION }}.tar.gz
+            agent-config-manager-${{ steps.version.outputs.VERSION }}.zip
+
+  publish-npm:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    needs: release
+    environment: npm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Setup Node.js for npm publish
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build
+        run: bun run build
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,82 @@
+# Changelog
+
+All notable changes to Agent Config Manager are documented here.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+---
+
+## [Unreleased]
+
+---
+
+## [0.1.0] - 2026-03-04
+
+Initial release of Agent Config Manager.
+
+### Added
+
+**Memory & Knowledge**
+- Memory Dashboard with storage health overview, usage donut chart, and per-harness stats
+- Session Memory manager with bulk select, delete, archive, export, and auto-prune settings
+- Learnings knowledge base with category filtering, search, import/export
+- Project Context editor with Monaco editor, live markdown preview, and built-in templates
+- External Context manager for portable context on external drives
+
+**Configuration**
+- Settings Editor with inline editing, diff preview, reset to defaults, and modified indicators
+- Skills Manager with Monaco editor, syntax highlighting, and category organisation
+- Tools Registry with harness filter, MCP-only filter, and usage stats
+- Hooks System with trigger types, enable/disable toggle, regex tool matcher, community templates
+
+**Workflows**
+- Unified Search (⌘K) across sessions, skills, settings, tools, hooks, and learnings
+- Cross-Harness Migration Wizard with compatibility analysis and one-click rollback
+- Sync & Backup with rotation management, restore points, and per-harness sync status
+- Notifications & Alerts with real-time toasts and alert history
+
+**Supported Harnesses**
+- Claude Code (`~/.claude/`)
+- Cursor (`~/.cursor/`)
+- GitHub Copilot (VS Code settings)
+- Cline (`~/.cline/`)
+- Continue (`~/.continue/`)
+- Aider (`~/.aider.conf.yml`)
+
+**Performance**
+- Code splitting via React.lazy + Suspense for all 14 tab pages
+- List virtualisation with @tanstack/react-virtual (10k+ items render smoothly)
+- Component memoisation (React.memo, useMemo, useCallback) on hot-path components
+- Manual Vite chunks for vendor libraries (React, Monaco, Recharts, Radix)
+- Web Vitals monitoring built in
+
+**Quality**
+- 1 200+ unit tests across services, stores, and components
+- 80%+ line coverage; service adapters at 84%+
+- Full TypeScript strict mode
+- ESLint + Prettier enforced via Husky pre-commit hooks
+- GitHub Actions CI (lint → test → build) on every PR
+
+**Documentation**
+- [User Guide](./docs/USER_GUIDE.md) — complete feature walkthrough
+- [Plugin API](./docs/PLUGIN_API.md) — how to write a custom harness adapter
+- [Contributing](./CONTRIBUTING.md) — contribution guidelines and PR process
+- [Troubleshooting](./docs/TROUBLESHOOTING.md) — common issues and solutions
+
+### Technical Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Framework | React 19 + TypeScript 5.9 |
+| Build | Vite 7 |
+| Styling | Tailwind CSS 4 + shadcn/ui |
+| State | Zustand 5 |
+| Code Editor | Monaco Editor |
+| Charts | Recharts |
+| Virtualisation | @tanstack/react-virtual |
+| Testing | Vitest + Testing Library |
+| Package Manager | Bun |
+
+[Unreleased]: https://github.com/jpequegn/agent-config-manager/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/jpequegn/agent-config-manager/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -56,12 +56,22 @@ Harnesses are auto-detected on startup from your home directory.
 
 ## Getting Started
 
-### Prerequisites
+### Install from npm (recommended)
 
-- [Node.js](https://nodejs.org/) 18+ or [Bun](https://bun.sh/) 1.0+
-- macOS, Linux, or Windows
+```bash
+npm install -g agent-config-manager
+agent-config-manager
+```
 
-### Installation
+The app opens automatically in your browser at `http://localhost:5173`.
+
+### Run without installing
+
+```bash
+npx agent-config-manager
+```
+
+### Local development
 
 ```bash
 # Clone the repository
@@ -162,7 +172,7 @@ bun run test:run          # all tests
 bun run test:coverage     # with coverage report
 ```
 
-All 1000+ tests run in under 25 seconds using Vitest in jsdom.
+All 1200+ tests run in under 25 seconds using Vitest in jsdom.
 
 ---
 
@@ -170,6 +180,7 @@ All 1000+ tests run in under 25 seconds using Vitest in jsdom.
 
 | Document | Description |
 |----------|-------------|
+| [Changelog](./CHANGELOG.md) | Release history and what's new |
 | [User Guide](./docs/USER_GUIDE.md) | Feature walkthroughs, keyboard shortcuts, and workflows |
 | [Plugin API](./docs/PLUGIN_API.md) | How to write a custom harness adapter |
 | [Contributing](./CONTRIBUTING.md) | Contribution guidelines and PR process |

--- a/bin/agent-config-manager.mjs
+++ b/bin/agent-config-manager.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+/**
+ * Agent Config Manager CLI
+ * Serves the built app and opens it in the browser
+ */
+
+import { createServer } from 'http'
+import { readFile, stat } from 'fs/promises'
+import { join, extname, dirname } from 'path'
+import { fileURLToPath } from 'url'
+import { createReadStream } from 'fs'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const distDir = join(__dirname, '..', 'dist')
+
+const MIME_TYPES = {
+  '.html': 'text/html',
+  '.js': 'application/javascript',
+  '.css': 'text/css',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.ico': 'image/x-icon',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+  '.json': 'application/json',
+}
+
+const DEFAULT_PORT = 5173
+
+async function serveFile(filePath, res) {
+  try {
+    await stat(filePath)
+    const ext = extname(filePath)
+    const contentType = MIME_TYPES[ext] || 'application/octet-stream'
+    res.writeHead(200, { 'Content-Type': contentType })
+    createReadStream(filePath).pipe(res)
+  } catch {
+    // Fall back to index.html for SPA routing
+    const indexPath = join(distDir, 'index.html')
+    res.writeHead(200, { 'Content-Type': 'text/html' })
+    createReadStream(indexPath).pipe(res)
+  }
+}
+
+async function checkDist() {
+  try {
+    await stat(join(distDir, 'index.html'))
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function openBrowser(url) {
+  const { platform } = process
+  const { exec } = await import('child_process')
+  const command =
+    platform === 'darwin' ? 'open' : platform === 'win32' ? 'start' : 'xdg-open'
+  exec(`${command} ${url}`)
+}
+
+async function main() {
+  const hasDist = await checkDist()
+  if (!hasDist) {
+    console.error(
+      '❌  No built app found. The dist/ directory is missing.\n' +
+        '   If you installed from npm, this is a packaging issue.\n' +
+        '   If you cloned the repo, run: bun run build'
+    )
+    process.exit(1)
+  }
+
+  const port = parseInt(process.env.PORT || String(DEFAULT_PORT), 10)
+
+  const server = createServer(async (req, res) => {
+    const urlPath = req.url === '/' ? '/index.html' : req.url ?? '/index.html'
+    const filePath = join(distDir, urlPath.split('?')[0])
+    await serveFile(filePath, res)
+  })
+
+  server.listen(port, '127.0.0.1', async () => {
+    const url = `http://localhost:${port}`
+    console.log(`\n🚀  Agent Config Manager`)
+    console.log(`   Running at ${url}\n`)
+    console.log('   Press Ctrl+C to stop.\n')
+    await openBrowser(url)
+  })
+
+  server.on('error', (err) => {
+    if (err.code === 'EADDRINUSE') {
+      console.error(`❌  Port ${port} is already in use. Set PORT env var to use a different port.`)
+    } else {
+      console.error('❌  Server error:', err.message)
+    }
+    process.exit(1)
+  })
+}
+
+main()

--- a/package.json
+++ b/package.json
@@ -2,8 +2,20 @@
   "name": "agent-config-manager",
   "version": "0.1.0",
   "description": "Unified UI for managing AI coding agent configurations",
-  "private": true,
   "type": "module",
+  "homepage": "https://github.com/jpequegn/agent-config-manager#readme",
+  "bin": {
+    "agent-config-manager": "./bin/agent-config-manager.mjs"
+  },
+  "files": [
+    "dist/",
+    "bin/",
+    "README.md",
+    "LICENSE"
+  ],
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",


### PR DESCRIPTION
## Summary
- Add `bin/agent-config-manager.mjs` — minimal Node.js static server CLI that serves the built app and auto-opens the browser (no extra runtime dependencies)
- Remove `"private": true` from `package.json`; add `bin`, `files`, `engines` fields so the package can be installed via `npm install -g agent-config-manager` or `npx agent-config-manager`
- Add `.github/workflows/release.yml` — tag-triggered workflow (`v*`) that: runs tests, builds the project, creates a GitHub Release with `.tar.gz` / `.zip` archives, then publishes to npm (requires `NPM_TOKEN` secret and `npm` environment)
- Add `CHANGELOG.md` documenting the full v0.1.0 feature set
- Update `README.md` with npm / npx install instructions, changelog link, and correct test count (1200+)

## Testing
- `bun run build` succeeds
- `bun run test:run` — all 1226 tests pass
- `bun run lint` — 0 errors (7 pre-existing warnings)
- CLI script: `node bin/agent-config-manager.mjs` correctly serves `dist/` and opens browser

## Related
Closes #52

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)